### PR TITLE
Upgraded Monolog to 3.7

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Fixed
 
+## [1.8.0] - 2024-09-25
+### Added
+- Upgraded Monolog to 3.7
+
 ## [1.7.0] - 2023-03-23
 ### Added
 - Added support for PHP 8

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "aws/aws-sdk-php": "^3.190",
         "ext-openssl": "*",
         "maxbanton/cwh": "^2.0",
-        "monolog/monolog": "^3.9",
+        "monolog/monolog": "^3.7",
         "stechstudio/backoff": "^1.2"
     },
     "require-dev": {


### PR DESCRIPTION
As Monolog 3.9 is still in [dev] mode, we need to set it to 3.7